### PR TITLE
fix: 클라이언트에서 Response Header 불러올 수 있도록 CORS 정책 추가

### DIFF
--- a/server/src/main/java/server/beerfactory/auth/config/SecurityConfig.java
+++ b/server/src/main/java/server/beerfactory/auth/config/SecurityConfig.java
@@ -43,9 +43,9 @@ public class SecurityConfig {
                 .headers().frameOptions().sameOrigin()
                 .and()
                 .csrf().disable()
+//                .cors(withDefaults())
                 .cors().configurationSource(corsConfigurationSource())
                 .and()
-//                .cors(withDefaults()) // corsConfigurationSource Bean을 이용함
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .formLogin().disable()
@@ -87,7 +87,10 @@ public class SecurityConfig {
     @Bean
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
         config.addAllowedHeader("*");
+        config.addExposedHeader("Authorization");
+        config.addExposedHeader("Refresh");
         config.setAllowedOrigins(Arrays.asList("*"));
         config.setAllowedMethods(Arrays.asList("POST", "PATCH", "GET", "DELETE"));
 

--- a/server/src/main/java/server/beerfactory/auth/userdetails/CustomUserDetailsService.java
+++ b/server/src/main/java/server/beerfactory/auth/userdetails/CustomUserDetailsService.java
@@ -30,7 +30,6 @@ public class CustomUserDetailsService implements UserDetailsService {
     }
 
     public final class CustomUserDetails extends User implements UserDetails {
-
         CustomUserDetails(User user) {
             setId(user.getId());
             setEmail(user.getEmail());

--- a/server/src/main/java/server/beerfactory/auth/utils/CustomAuthorityUtils.java
+++ b/server/src/main/java/server/beerfactory/auth/utils/CustomAuthorityUtils.java
@@ -1,7 +1,6 @@
 package server.beerfactory.auth.utils;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;

--- a/server/src/main/java/server/beerfactory/controller/user/UserController.java
+++ b/server/src/main/java/server/beerfactory/controller/user/UserController.java
@@ -1,6 +1,7 @@
 package server.beerfactory.controller.user;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -13,6 +14,7 @@ import server.beerfactory.service.user.UserService;
 @RequiredArgsConstructor
 @Validated
 @RestController
+@Slf4j
 @RequestMapping("/users")
 public class UserController {
     private final UserService userService;


### PR DESCRIPTION
로그인에 성공했을때 Response Header로 access token(Authorization), refresh token(Refresh)이 출력되는데,

이 값을 클라이언트에서 불러오지 못하는 문제를 해결했습니다.

SecurityConfig 클래스의 CORS 정책에서
        config.addExposedHeader("Authorization");
        config.addExposedHeader("Refresh");
추가해줬습니다.